### PR TITLE
Update EditTemplate/title with warning about invalid characters

### DIFF
--- a/plugins/relink/tiddlers/overrides/core_ui_EditTemplate_title.tid
+++ b/plugins/relink/tiddlers/overrides/core_ui_EditTemplate_title.tid
@@ -5,6 +5,20 @@ title: $:/core/ui/EditTemplate/title
 
 <$reveal state="!!draft.title" type="nomatch" text={{!!draft.of}} tag="div">
 
+<$vars pattern="""[\|\[\]{}]""" bad-chars="""`| [ ] { }`""">
+
+<$list filter="[all[current]regexp:draft.title<pattern>]" variable="listItem">
+
+<div class="tc-message-box">
+
+{{$:/core/images/warning}} {{$:/language/EditTemplate/Title/BadCharacterWarning}}
+
+</div>
+
+</$list>
+
+</$vars>
+
 <$list filter="[{!!draft.title}!is[missing]]" variable="listItem">
 
 <div class="tc-message-box">


### PR DESCRIPTION
Update `$:/core/ui/EditTemplate/title` with warning about invalid characters in titles.

This makes it consistent with the [current core behaviour](https://github.com/Jermolene/TiddlyWiki5/blob/master/core/ui/EditTemplate/title.tid)